### PR TITLE
Refactor MainWindow left panel layout and shortcuts

### DIFF
--- a/ui_qt/MainWindow.cpp
+++ b/ui_qt/MainWindow.cpp
@@ -1,77 +1,136 @@
 #include "MainWindow.h"
+#include <QSplitter>
+#include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QGridLayout>
 #include <QGroupBox>
-#include <QWidget>
+#include <QStyle>
+#include <QAction>
 #include <QCoreApplication>
-#include <QKeyEvent>
 #include <QFont>
 #include <QScrollBar>
 #include <QStatusBar>
 #include "../core/Command.h"
 
-
 MainWindow::MainWindow(QWidget* parent):QMainWindow(parent){
     resize(1100,720);
     setMinimumSize(1000,640);
 
-    auto* central = new QWidget(this);
-    auto* h = new QHBoxLayout(central);
+    auto* splitter = new QSplitter(Qt::Horizontal, this);
+    setCentralWidget(splitter);
 
-    auto* grpAct = new QGroupBox(QStringLiteral("行动"), central);
+    auto* leftPane = new QWidget(splitter);
+    leftPane->setMaximumWidth(320);
+    auto* leftLayout = new QVBoxLayout(leftPane);
+    leftLayout->setContentsMargins(12,12,12,12);
+    leftLayout->setSpacing(8);
+
+    auto* grpMove = new QGroupBox(QStringLiteral("移动"), leftPane);
     auto* g = new QGridLayout();
-    btnN_ = new QPushButton(QStringLiteral("北(W)"));
-    btnS_ = new QPushButton(QStringLiteral("南(S)"));
-    btnW_ = new QPushButton(QStringLiteral("西(A)"));
-    btnE_ = new QPushButton(QStringLiteral("东(D)"));
-    btnTalk_ = new QPushButton(QStringLiteral("对话(J)"));
-    btnAttack_ = new QPushButton(QStringLiteral("攻击(K)"));
-    btnSave_ = new QPushButton(QStringLiteral("存档(F5)"));
-    btnLoad_ = new QPushButton(QStringLiteral("读档(F9)"));
-
+    btnN_ = new QPushButton();
+    btnS_ = new QPushButton();
+    btnW_ = new QPushButton();
+    btnE_ = new QPushButton();
+    for(auto btn : {btnN_,btnS_,btnW_,btnE_}){
+        btn->setFixedSize(64,64);
+        btn->setAutoDefault(false);
+        btn->setDefault(false);
+    }
+    btnN_->setIcon(style()->standardIcon(QStyle::SP_ArrowUp));
+    btnS_->setIcon(style()->standardIcon(QStyle::SP_ArrowDown));
+    btnW_->setIcon(style()->standardIcon(QStyle::SP_ArrowLeft));
+    btnE_->setIcon(style()->standardIcon(QStyle::SP_ArrowRight));
+    btnN_->setToolTip(QStringLiteral("热键: W"));
+    btnS_->setToolTip(QStringLiteral("热键: S"));
+    btnW_->setToolTip(QStringLiteral("热键: A"));
+    btnE_->setToolTip(QStringLiteral("热键: D"));
     g->addWidget(btnN_,0,1);
     g->addWidget(btnW_,1,0);
-    g->addWidget(btnS_,1,1);
     g->addWidget(btnE_,1,2);
-    g->addWidget(btnTalk_,2,0);
-    g->addWidget(btnAttack_,2,1);
-    g->addWidget(btnSave_,3,0);
-    g->addWidget(btnLoad_,3,1);
-    grpAct->setLayout(g);
+    g->addWidget(btnS_,2,1);
+    grpMove->setLayout(g);
+    leftLayout->addWidget(grpMove);
 
-    log_ = new QPlainTextEdit(central);
+    auto* grpInteract = new QGroupBox(QStringLiteral("交互"), leftPane);
+    auto* hbInteract = new QHBoxLayout();
+    btnTalk_ = new QPushButton(QStringLiteral("对话 J"));
+    btnAttack_ = new QPushButton(QStringLiteral("攻击 K"));
+    for(auto btn : {btnTalk_,btnAttack_}){
+        btn->setMinimumSize(96,44);
+        btn->setAutoDefault(false);
+        btn->setDefault(false);
+    }
+    hbInteract->addWidget(btnTalk_);
+    hbInteract->addWidget(btnAttack_);
+    grpInteract->setLayout(hbInteract);
+    leftLayout->addWidget(grpInteract);
+
+    auto* grpSystem = new QGroupBox(QStringLiteral("系统"), leftPane);
+    auto* hbSystem = new QHBoxLayout();
+    btnSave_ = new QPushButton(QStringLiteral("存档 F5"));
+    btnLoad_ = new QPushButton(QStringLiteral("读档 F9"));
+    btnClear_ = new QPushButton(QStringLiteral("清屏"));
+    for(auto btn : {btnSave_,btnLoad_,btnClear_}){
+        btn->setMinimumSize(84,36);
+        btn->setAutoDefault(false);
+        btn->setDefault(false);
+    }
+    hbSystem->addWidget(btnSave_);
+    hbSystem->addWidget(btnLoad_);
+    hbSystem->addWidget(btnClear_);
+    grpSystem->setLayout(hbSystem);
+    leftLayout->addWidget(grpSystem);
+
+    log_ = new QPlainTextEdit(splitter);
     log_->setReadOnly(true);
     log_->setFocusPolicy(Qt::NoFocus);
     log_->setFont(QFont("Consolas",11));
 
-    h->addWidget(grpAct);
-    h->addWidget(log_,1);
-    setCentralWidget(central);
-    setStyleSheet("QPushButton{min-width:120px;min-height:48px;font-size:14px;border-radius:6px;} QPushButton:hover{background-color:#e0e0e0;}");
+    splitter->addWidget(leftPane);
+    splitter->addWidget(log_);
+    splitter->setStretchFactor(0,0);
+    splitter->setStretchFactor(1,1);
 
-    btnN_->setShortcut(Qt::Key_W);
-    btnS_->setShortcut(Qt::Key_S);
-    btnW_->setShortcut(Qt::Key_A);
-    btnE_->setShortcut(Qt::Key_D);
-    btnTalk_->setShortcut(Qt::Key_J);
-    btnAttack_->setShortcut(Qt::Key_K);
-    btnSave_->setShortcut(Qt::Key_F5);
-    btnLoad_->setShortcut(Qt::Key_F9);
+    setStyleSheet(
+        "QGroupBox { border: 1px solid #d9d9e3; border-radius: 8px; margin-top: 8px; padding: 8px 8px 4px 8px; }"
+        "QGroupBox::title { subcontrol-origin: margin; left: 10px; padding: 0 4px; color: #555; }"
+        "QPushButton { border-radius: 6px; padding: 6px 10px; }"
+        "QPushButton:hover { background: #f2f3f7; }"
+        "QPushButton:pressed { background: #e6e8ef; }"
+    );
 
     world_.LoadData((QCoreApplication::applicationDirPath()+"/../data").toStdString());
     append("世界已加载。");
     refreshHud();
 
-    connect(btnN_, &QPushButton::clicked, this, [this]{ append(QString::fromStdString(Execute(world_, world_.playerId(), {"go","north",{}}))); refreshHud(); });
-    connect(btnS_, &QPushButton::clicked, this, [this]{ append(QString::fromStdString(Execute(world_, world_.playerId(), {"go","south",{}}))); refreshHud(); });
-    connect(btnW_, &QPushButton::clicked, this, [this]{ append(QString::fromStdString(Execute(world_, world_.playerId(), {"go","west",{}}))); refreshHud(); });
-    connect(btnE_, &QPushButton::clicked, this, [this]{ append(QString::fromStdString(Execute(world_, world_.playerId(), {"go","east",{}}))); refreshHud(); });
+    auto moveNorth = [this]{ append(QString::fromStdString(Execute(world_, world_.playerId(), {"go","north",{}}))); refreshHud(); };
+    auto moveSouth = [this]{ append(QString::fromStdString(Execute(world_, world_.playerId(), {"go","south",{}}))); refreshHud(); };
+    auto moveWest  = [this]{ append(QString::fromStdString(Execute(world_, world_.playerId(), {"go","west",{}}))); refreshHud(); };
+    auto moveEast  = [this]{ append(QString::fromStdString(Execute(world_, world_.playerId(), {"go","east",{}}))); refreshHud(); };
+    auto talk      = [this]{ append(QString::fromStdString(Execute(world_, world_.playerId(), {"talk","nearest",{}}))); refreshHud(); };
+    auto attack    = [this]{ append(QString::fromStdString(Execute(world_, world_.playerId(), {"attack","nearest",{}}))); refreshHud(); };
+    auto save      = [this]{ append(QString::fromStdString(world_.Save("save1.json"))); };
+    auto load      = [this]{ append(QString::fromStdString(world_.Load("save1.json"))); refreshHud(); };
+    auto clearLog  = [this]{ log_->clear(); };
 
-    connect(btnTalk_, &QPushButton::clicked, this, [this]{ append(QString::fromStdString(Execute(world_, world_.playerId(), {"talk","nearest",{}}))); refreshHud(); });
-    connect(btnAttack_, &QPushButton::clicked, this, [this]{ append(QString::fromStdString(Execute(world_, world_.playerId(), {"attack","nearest",{}}))); refreshHud(); });
+    connect(btnN_, &QPushButton::clicked, this, moveNorth);
+    connect(btnS_, &QPushButton::clicked, this, moveSouth);
+    connect(btnW_, &QPushButton::clicked, this, moveWest);
+    connect(btnE_, &QPushButton::clicked, this, moveEast);
+    connect(btnTalk_, &QPushButton::clicked, this, talk);
+    connect(btnAttack_, &QPushButton::clicked, this, attack);
+    connect(btnSave_, &QPushButton::clicked, this, save);
+    connect(btnLoad_, &QPushButton::clicked, this, load);
+    connect(btnClear_, &QPushButton::clicked, this, clearLog);
 
-    connect(btnSave_, &QPushButton::clicked, this, [this]{ append(QString::fromStdString(world_.Save("save1.json"))); });
-    connect(btnLoad_, &QPushButton::clicked, this, [this]{ append(QString::fromStdString(world_.Load("save1.json"))); refreshHud(); });
+    auto* actN = new QAction(this); actN->setShortcut(Qt::Key_W); connect(actN, &QAction::triggered, this, moveNorth);
+    auto* actS = new QAction(this); actS->setShortcut(Qt::Key_S); connect(actS, &QAction::triggered, this, moveSouth);
+    auto* actW = new QAction(this); actW->setShortcut(Qt::Key_A); connect(actW, &QAction::triggered, this, moveWest);
+    auto* actE = new QAction(this); actE->setShortcut(Qt::Key_D); connect(actE, &QAction::triggered, this, moveEast);
+    auto* actTalk = new QAction(this); actTalk->setShortcut(Qt::Key_J); connect(actTalk, &QAction::triggered, this, talk);
+    auto* actAttack = new QAction(this); actAttack->setShortcut(Qt::Key_K); connect(actAttack, &QAction::triggered, this, attack);
+    auto* actSave = new QAction(this); actSave->setShortcut(Qt::Key_F5); connect(actSave, &QAction::triggered, this, save);
+    auto* actLoad = new QAction(this); actLoad->setShortcut(Qt::Key_F9); connect(actLoad, &QAction::triggered, this, load);
 
     timer_ = new QTimer(this);
     connect(timer_, &QTimer::timeout, this, [this]{ world_.TickHours(1); ++tick_; refreshHud(); });
@@ -83,23 +142,10 @@ void MainWindow::append(const QString& s){
     auto* bar = log_->verticalScrollBar();
     bar->setValue(bar->maximum());
 }
+
 void MainWindow::refreshHud(){
     if(auto* p = world_.Find(world_.playerId())){
         statusBar()->showMessage(QString("X:%1 Y:%2 | Tick:%3").arg(p->pos.x).arg(p->pos.y).arg(tick_));
     }
 }
 
-void MainWindow::keyPressEvent(QKeyEvent* e) {
-    switch (e->key()) {
-    case Qt::Key_W: btnN_->animateClick(); break;
-    case Qt::Key_S: btnS_->animateClick(); break;
-    case Qt::Key_A: btnW_->animateClick(); break;
-    case Qt::Key_D: btnE_->animateClick(); break;
-    case Qt::Key_J: btnTalk_->animateClick(); break;
-    case Qt::Key_K: btnAttack_->animateClick(); break;
-    case Qt::Key_F5: btnSave_->animateClick(); break;
-    case Qt::Key_F9: btnLoad_->animateClick(); break;
-    default:
-        QMainWindow::keyPressEvent(e);
-    }
-}

--- a/ui_qt/MainWindow.h
+++ b/ui_qt/MainWindow.h
@@ -3,7 +3,6 @@
 #include <QTimer>
 #include <QPlainTextEdit>
 #include <QPushButton>
-#include <QKeyEvent>
 #include "../core/World.h"
 
 class MainWindow : public QMainWindow {
@@ -11,12 +10,10 @@ class MainWindow : public QMainWindow {
 public:
     MainWindow(QWidget* parent=nullptr);
 
-protected:
-    void keyPressEvent(QKeyEvent* e) override;
 private:
     World world_;
     QPlainTextEdit* log_;
-    QPushButton *btnN_,*btnS_,*btnW_,*btnE_,*btnTalk_,*btnAttack_,*btnSave_,*btnLoad_;
+    QPushButton *btnN_,*btnS_,*btnW_,*btnE_,*btnTalk_,*btnAttack_,*btnSave_,*btnLoad_,*btnClear_;
     QTimer* timer_;
     int tick_=0;
     void append(const QString& s);


### PR DESCRIPTION
## Summary
- Rebuild MainWindow with QSplitter-based left/right layout and left pane group boxes for movement, interaction, and system controls
- Add keyboard shortcut QActions and styling for new buttons including clear log

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68971a12f6f0832cb6dcf1817f4ae3c8