### PR TITLE
feat: upgrade Qt UI with D-pad icons and beige theme

### DIFF
--- a/ui_qt/CMakeLists.txt
+++ b/ui_qt/CMakeLists.txt
@@ -11,6 +11,8 @@ add_executable(ui_qt
   MainWindow.h
 )
 
+qt5_add_resources(ui_qt_resources resources/ui_qt.qrc)
+target_sources(ui_qt PRIVATE ${ui_qt_resources})
 
 target_link_libraries(ui_qt PRIVATE core Qt${QT_VERSION_MAJOR}::Widgets)
 target_include_directories(ui_qt PRIVATE ${CMAKE_SOURCE_DIR}/core)

--- a/ui_qt/MainWindow.cpp
+++ b/ui_qt/MainWindow.cpp
@@ -4,62 +4,83 @@
 #include <QHBoxLayout>
 #include <QGridLayout>
 #include <QGroupBox>
-#include <QStyle>
 #include <QAction>
 #include <QCoreApplication>
-#include <QFont>
 #include <QScrollBar>
 #include <QStatusBar>
+#include <QFontDatabase>
+#include <QFile>
+#include <QTextCursor>
 #include "../core/Command.h"
 
-MainWindow::MainWindow(QWidget* parent):QMainWindow(parent){
-    resize(1100,720);
-    setMinimumSize(1000,640);
+MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent) {
+    resize(1100, 720);
+    setMinimumSize(1000, 640);
 
     auto* splitter = new QSplitter(Qt::Horizontal, this);
     setCentralWidget(splitter);
 
     auto* leftPane = new QWidget(splitter);
+    leftPane->setObjectName("LeftPane");
     leftPane->setMaximumWidth(320);
     auto* leftLayout = new QVBoxLayout(leftPane);
-    leftLayout->setContentsMargins(12,12,12,12);
-    leftLayout->setSpacing(8);
+    leftLayout->setContentsMargins(12, 12, 12, 12);
+    leftLayout->setSpacing(10);
 
     auto* grpMove = new QGroupBox(QStringLiteral("移动"), leftPane);
     auto* g = new QGridLayout();
+    g->setHorizontalSpacing(8);
+    g->setVerticalSpacing(8);
     btnN_ = new QPushButton();
     btnS_ = new QPushButton();
     btnW_ = new QPushButton();
     btnE_ = new QPushButton();
-    for(auto btn : {btnN_,btnS_,btnW_,btnE_}){
-        btn->setFixedSize(64,64);
+    auto* btnC = new QPushButton();
+    for (auto btn : {btnN_, btnS_, btnW_, btnE_, btnC}) {
+        btn->setFixedSize(64, 64);
+        btn->setIconSize(QSize(28, 28));
         btn->setAutoDefault(false);
         btn->setDefault(false);
     }
-    btnN_->setIcon(style()->standardIcon(QStyle::SP_ArrowUp));
-    btnS_->setIcon(style()->standardIcon(QStyle::SP_ArrowDown));
-    btnW_->setIcon(style()->standardIcon(QStyle::SP_ArrowLeft));
-    btnE_->setIcon(style()->standardIcon(QStyle::SP_ArrowRight));
-    btnN_->setToolTip(QStringLiteral("热键: W"));
-    btnS_->setToolTip(QStringLiteral("热键: S"));
-    btnW_->setToolTip(QStringLiteral("热键: A"));
-    btnE_->setToolTip(QStringLiteral("热键: D"));
-    g->addWidget(btnN_,0,1);
-    g->addWidget(btnW_,1,0);
-    g->addWidget(btnE_,1,2);
-    g->addWidget(btnS_,2,1);
+    QIcon icUp(":/icons/arrow_up.svg");
+    if (icUp.isNull()) btnN_->setText(QString::fromUtf8("▲")); else btnN_->setIcon(icUp);
+    QIcon icDown(":/icons/arrow_down.svg");
+    if (icDown.isNull()) btnS_->setText(QString::fromUtf8("▼")); else btnS_->setIcon(icDown);
+    QIcon icLeft(":/icons/arrow_left.svg");
+    if (icLeft.isNull()) btnW_->setText(QString::fromUtf8("◀")); else btnW_->setIcon(icLeft);
+    QIcon icRight(":/icons/arrow_right.svg");
+    if (icRight.isNull()) btnE_->setText(QString::fromUtf8("▶")); else btnE_->setIcon(icRight);
+    QIcon icCenter(":/icons/dot_center.svg");
+    if (icCenter.isNull()) btnC->setText(QString::fromUtf8("•")); else btnC->setIcon(icCenter);
+    btnC->setEnabled(false);
+    btnN_->setToolTip("W");
+    btnS_->setToolTip("S");
+    btnW_->setToolTip("A");
+    btnE_->setToolTip("D");
+    g->addItem(new QSpacerItem(64, 64), 0, 0);
+    g->addWidget(btnN_, 0, 1);
+    g->addItem(new QSpacerItem(64, 64), 0, 2);
+    g->addWidget(btnW_, 1, 0);
+    g->addWidget(btnC, 1, 1);
+    g->addWidget(btnE_, 1, 2);
+    g->addItem(new QSpacerItem(64, 64), 2, 0);
+    g->addWidget(btnS_, 2, 1);
+    g->addItem(new QSpacerItem(64, 64), 2, 2);
     grpMove->setLayout(g);
     leftLayout->addWidget(grpMove);
 
     auto* grpInteract = new QGroupBox(QStringLiteral("交互"), leftPane);
     auto* hbInteract = new QHBoxLayout();
-    btnTalk_ = new QPushButton(QStringLiteral("对话 J"));
-    btnAttack_ = new QPushButton(QStringLiteral("攻击 K"));
-    for(auto btn : {btnTalk_,btnAttack_}){
-        btn->setMinimumSize(96,44);
+    hbInteract->setSpacing(8);
+    btnTalk_ = new QPushButton();
+    btnAttack_ = new QPushButton();
+    for (auto btn : {btnTalk_, btnAttack_}) {
+        btn->setMinimumSize(96, 44);
         btn->setAutoDefault(false);
         btn->setDefault(false);
     }
+    btnTalk_->setText(QStringLiteral("对话 <span style='color:#9ca3af'>(J)</span>"));
+    btnAttack_->setText(QStringLiteral("攻击 <span style='color:#9ca3af'>(K)</span>"));
     hbInteract->addWidget(btnTalk_);
     hbInteract->addWidget(btnAttack_);
     grpInteract->setLayout(hbInteract);
@@ -67,14 +88,18 @@ MainWindow::MainWindow(QWidget* parent):QMainWindow(parent){
 
     auto* grpSystem = new QGroupBox(QStringLiteral("系统"), leftPane);
     auto* hbSystem = new QHBoxLayout();
-    btnSave_ = new QPushButton(QStringLiteral("存档 F5"));
-    btnLoad_ = new QPushButton(QStringLiteral("读档 F9"));
-    btnClear_ = new QPushButton(QStringLiteral("清屏"));
-    for(auto btn : {btnSave_,btnLoad_,btnClear_}){
-        btn->setMinimumSize(84,36);
+    hbSystem->setSpacing(8);
+    btnSave_ = new QPushButton();
+    btnLoad_ = new QPushButton();
+    btnClear_ = new QPushButton();
+    for (auto btn : {btnSave_, btnLoad_, btnClear_}) {
+        btn->setMinimumSize(84, 36);
         btn->setAutoDefault(false);
         btn->setDefault(false);
     }
+    btnSave_->setText(QStringLiteral("存档 <span style='color:#9ca3af'>(F5)</span>"));
+    btnLoad_->setText(QStringLiteral("读档 <span style='color:#9ca3af'>(F9)</span>"));
+    btnClear_->setText(QStringLiteral("清屏"));
     hbSystem->addWidget(btnSave_);
     hbSystem->addWidget(btnLoad_);
     hbSystem->addWidget(btnClear_);
@@ -84,68 +109,128 @@ MainWindow::MainWindow(QWidget* parent):QMainWindow(parent){
     log_ = new QPlainTextEdit(splitter);
     log_->setReadOnly(true);
     log_->setFocusPolicy(Qt::NoFocus);
-    log_->setFont(QFont("Consolas",11));
+    log_->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
 
     splitter->addWidget(leftPane);
     splitter->addWidget(log_);
-    splitter->setStretchFactor(0,0);
-    splitter->setStretchFactor(1,1);
+    splitter->setStretchFactor(0, 0);
+    splitter->setStretchFactor(1, 1);
 
     setStyleSheet(
-        "QGroupBox { border: 1px solid #d9d9e3; border-radius: 8px; margin-top: 8px; padding: 8px 8px 4px 8px; }"
-        "QGroupBox::title { subcontrol-origin: margin; left: 10px; padding: 0 4px; color: #555; }"
-        "QPushButton { border-radius: 6px; padding: 6px 10px; }"
-        "QPushButton:hover { background: #f2f3f7; }"
-        "QPushButton:pressed { background: #e6e8ef; }"
+        "QWidget#LeftPane { background: #f6f3ea; }"
+        "QGroupBox {"
+        "  border: 1px solid #dad7cf; border-radius: 10px;"
+        "  margin-top: 10px; padding: 8px 10px 10px 10px;"
+        "  background: rgba(255,255,255,0.55);"
+        "}"
+        "QGroupBox::title { subcontrol-origin: margin; left: 12px; padding: 0 4px; color: #6b7280; }"
+        "QPushButton { border: 1px solid #d4d4d8; border-radius: 8px; padding: 6px 10px; }"
+        "QPushButton:hover { background: #eef2ff; }"
+        "QPushButton:pressed { background: #e0e7ff; }"
+        "QPushButton:disabled { background: transparent; border: 1px dashed #d4d4d8; color: #9ca3af; }"
+        "QPlainTextEdit { background: #ffffff; selection-background-color: #e5e7eb; }"
+        "QStatusBar { color: #374151; }"
     );
 
-    world_.LoadData((QCoreApplication::applicationDirPath()+"/../data").toStdString());
-    append("世界已加载。");
+    auto dataPath = QCoreApplication::applicationDirPath() + "/../data";
+    world_.LoadData(dataPath.toStdString());
+    QFile vf(dataPath + "/_version");
+    if (vf.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        dataVersion_ = QString::fromUtf8(vf.readAll()).trimmed();
+    }
+    append(QStringLiteral("世界已加载。"));
     refreshHud();
 
-    auto moveNorth = [this]{ append(QString::fromStdString(Execute(world_, world_.playerId(), {"go","north",{}}))); refreshHud(); };
-    auto moveSouth = [this]{ append(QString::fromStdString(Execute(world_, world_.playerId(), {"go","south",{}}))); refreshHud(); };
-    auto moveWest  = [this]{ append(QString::fromStdString(Execute(world_, world_.playerId(), {"go","west",{}}))); refreshHud(); };
-    auto moveEast  = [this]{ append(QString::fromStdString(Execute(world_, world_.playerId(), {"go","east",{}}))); refreshHud(); };
-    auto talk      = [this]{ append(QString::fromStdString(Execute(world_, world_.playerId(), {"talk","nearest",{}}))); refreshHud(); };
-    auto attack    = [this]{ append(QString::fromStdString(Execute(world_, world_.playerId(), {"attack","nearest",{}}))); refreshHud(); };
-    auto save      = [this]{ append(QString::fromStdString(world_.Save("save1.json"))); };
-    auto load      = [this]{ append(QString::fromStdString(world_.Load("save1.json"))); refreshHud(); };
-    auto clearLog  = [this]{ log_->clear(); };
+    auto actN = new QAction(this); actN->setShortcut(QKeySequence("W")); connect(actN, &QAction::triggered, this, &MainWindow::onMoveNorth); addAction(actN);
+    auto actS = new QAction(this); actS->setShortcut(QKeySequence("S")); connect(actS, &QAction::triggered, this, &MainWindow::onMoveSouth); addAction(actS);
+    auto actW = new QAction(this); actW->setShortcut(QKeySequence("A")); connect(actW, &QAction::triggered, this, &MainWindow::onMoveWest); addAction(actW);
+    auto actE = new QAction(this); actE->setShortcut(QKeySequence("D")); connect(actE, &QAction::triggered, this, &MainWindow::onMoveEast); addAction(actE);
+    auto actTalk = new QAction(this); actTalk->setShortcut(QKeySequence("J")); connect(actTalk, &QAction::triggered, this, &MainWindow::onTalk); addAction(actTalk);
+    auto actAttack = new QAction(this); actAttack->setShortcut(QKeySequence("K")); connect(actAttack, &QAction::triggered, this, &MainWindow::onAttack); addAction(actAttack);
+    auto actSave = new QAction(this); actSave->setShortcut(QKeySequence("F5")); connect(actSave, &QAction::triggered, this, &MainWindow::onSave); addAction(actSave);
+    auto actLoad = new QAction(this); actLoad->setShortcut(QKeySequence("F9")); connect(actLoad, &QAction::triggered, this, &MainWindow::onLoad); addAction(actLoad);
 
-    connect(btnN_, &QPushButton::clicked, this, moveNorth);
-    connect(btnS_, &QPushButton::clicked, this, moveSouth);
-    connect(btnW_, &QPushButton::clicked, this, moveWest);
-    connect(btnE_, &QPushButton::clicked, this, moveEast);
-    connect(btnTalk_, &QPushButton::clicked, this, talk);
-    connect(btnAttack_, &QPushButton::clicked, this, attack);
-    connect(btnSave_, &QPushButton::clicked, this, save);
-    connect(btnLoad_, &QPushButton::clicked, this, load);
-    connect(btnClear_, &QPushButton::clicked, this, clearLog);
-
-    auto* actN = new QAction(this); actN->setShortcut(Qt::Key_W); connect(actN, &QAction::triggered, this, moveNorth); addAction(actN);
-    auto* actS = new QAction(this); actS->setShortcut(Qt::Key_S); connect(actS, &QAction::triggered, this, moveSouth); addAction(actS);
-    auto* actW = new QAction(this); actW->setShortcut(Qt::Key_A); connect(actW, &QAction::triggered, this, moveWest); addAction(actW);
-    auto* actE = new QAction(this); actE->setShortcut(Qt::Key_D); connect(actE, &QAction::triggered, this, moveEast); addAction(actE);
-    auto* actTalk = new QAction(this); actTalk->setShortcut(Qt::Key_J); connect(actTalk, &QAction::triggered, this, talk); addAction(actTalk);
-    auto* actAttack = new QAction(this); actAttack->setShortcut(Qt::Key_K); connect(actAttack, &QAction::triggered, this, attack); addAction(actAttack);
-    auto* actSave = new QAction(this); actSave->setShortcut(Qt::Key_F5); connect(actSave, &QAction::triggered, this, save); addAction(actSave);
-    auto* actLoad = new QAction(this); actLoad->setShortcut(Qt::Key_F9); connect(actLoad, &QAction::triggered, this, load); addAction(actLoad);
+    connect(btnN_, &QPushButton::clicked, this, &MainWindow::onMoveNorth);
+    connect(btnS_, &QPushButton::clicked, this, &MainWindow::onMoveSouth);
+    connect(btnW_, &QPushButton::clicked, this, &MainWindow::onMoveWest);
+    connect(btnE_, &QPushButton::clicked, this, &MainWindow::onMoveEast);
+    connect(btnTalk_, &QPushButton::clicked, this, &MainWindow::onTalk);
+    connect(btnAttack_, &QPushButton::clicked, this, &MainWindow::onAttack);
+    connect(btnSave_, &QPushButton::clicked, this, &MainWindow::onSave);
+    connect(btnLoad_, &QPushButton::clicked, this, &MainWindow::onLoad);
+    connect(btnClear_, &QPushButton::clicked, this, &MainWindow::onClear);
 
     timer_ = new QTimer(this);
-    connect(timer_, &QTimer::timeout, this, [this]{ world_.TickHours(1); ++tick_; refreshHud(); });
+    connect(timer_, &QTimer::timeout, this, [this] { world_.TickHours(1); ++tick_; refreshHud(); });
     timer_->start(500);
 }
 
-void MainWindow::append(const QString& s){
+void MainWindow::append(const QString& s) {
     log_->appendPlainText(s);
+    auto* doc = log_->document();
+    if (doc->blockCount() > 5000) {
+        QTextCursor c(doc);
+        c.movePosition(QTextCursor::Start);
+        for (int i = 0; i < 100 && doc->blockCount() > 5000; ++i) {
+            c.select(QTextCursor::LineUnderCursor);
+            c.removeSelectedText();
+            c.deleteChar();
+        }
+    }
     auto* bar = log_->verticalScrollBar();
     bar->setValue(bar->maximum());
 }
 
-void MainWindow::refreshHud(){
-    if(auto* p = world_.Find(world_.playerId())){
-        statusBar()->showMessage(QString("X:%1 Y:%2 | Tick:%3").arg(p->pos.x).arg(p->pos.y).arg(tick_));
+void MainWindow::refreshHud() {
+    QString msg;
+    if (auto* p = world_.Find(world_.playerId())) {
+        msg = QString("X:%1 Y:%2 | Tick:%3").arg(p->pos.x).arg(p->pos.y).arg(tick_);
     }
+    if (!dataVersion_.isEmpty()) {
+        msg += QString(" | Data v%1").arg(dataVersion_);
+    }
+    statusBar()->showMessage(msg);
 }
 
+void MainWindow::onMoveNorth() {
+    append(QString::fromStdString(Execute(world_, world_.playerId(), {"go", "north", {}})));
+    refreshHud();
+}
+
+void MainWindow::onMoveSouth() {
+    append(QString::fromStdString(Execute(world_, world_.playerId(), {"go", "south", {}})));
+    refreshHud();
+}
+
+void MainWindow::onMoveWest() {
+    append(QString::fromStdString(Execute(world_, world_.playerId(), {"go", "west", {}})));
+    refreshHud();
+}
+
+void MainWindow::onMoveEast() {
+    append(QString::fromStdString(Execute(world_, world_.playerId(), {"go", "east", {}})));
+    refreshHud();
+}
+
+void MainWindow::onTalk() {
+    append(QString::fromStdString(Execute(world_, world_.playerId(), {"talk", "nearest", {}})));
+    refreshHud();
+}
+
+void MainWindow::onAttack() {
+    append(QString::fromStdString(Execute(world_, world_.playerId(), {"attack", "nearest", {}})));
+    refreshHud();
+}
+
+void MainWindow::onSave() {
+    append(QString::fromStdString(world_.Save("save1.json")));
+}
+
+void MainWindow::onLoad() {
+    append(QString::fromStdString(world_.Load("save1.json")));
+    refreshHud();
+}
+
+void MainWindow::onClear() {
+    log_->clear();
+}

--- a/ui_qt/MainWindow.h
+++ b/ui_qt/MainWindow.h
@@ -16,6 +16,16 @@ private:
     QPushButton *btnN_,*btnS_,*btnW_,*btnE_,*btnTalk_,*btnAttack_,*btnSave_,*btnLoad_,*btnClear_;
     QTimer* timer_;
     int tick_=0;
+    QString dataVersion_;
     void append(const QString& s);
     void refreshHud();
+    void onMoveNorth();
+    void onMoveSouth();
+    void onMoveWest();
+    void onMoveEast();
+    void onTalk();
+    void onAttack();
+    void onSave();
+    void onLoad();
+    void onClear();
 };

--- a/ui_qt/resources/icons/arrow_down.svg
+++ b/ui_qt/resources/icons/arrow_down.svg
@@ -1,0 +1,3 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M32 52L52 32H40V12H24V32H12L32 52Z" fill="#4b5563" stroke="#111827" stroke-width="2.2" stroke-linejoin="round"/>
+</svg>

--- a/ui_qt/resources/icons/arrow_left.svg
+++ b/ui_qt/resources/icons/arrow_left.svg
@@ -1,0 +1,3 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 32L32 52V40H52V24H32V12L12 32Z" fill="#4b5563" stroke="#111827" stroke-width="2.2" stroke-linejoin="round"/>
+</svg>

--- a/ui_qt/resources/icons/arrow_right.svg
+++ b/ui_qt/resources/icons/arrow_right.svg
@@ -1,0 +1,3 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M52 32L32 12V24H12V40H32V52L52 32Z" fill="#4b5563" stroke="#111827" stroke-width="2.2" stroke-linejoin="round"/>
+</svg>

--- a/ui_qt/resources/icons/arrow_up.svg
+++ b/ui_qt/resources/icons/arrow_up.svg
@@ -1,0 +1,3 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M32 12L12 32H24V52H40V32H52L32 12Z" fill="#4b5563" stroke="#111827" stroke-width="2.2" stroke-linejoin="round"/>
+</svg>

--- a/ui_qt/resources/icons/dot_center.svg
+++ b/ui_qt/resources/icons/dot_center.svg
@@ -1,0 +1,3 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="32" cy="32" r="10" fill="#4b5563" stroke="#111827" stroke-width="2.2"/>
+</svg>

--- a/ui_qt/resources/ui_qt.qrc
+++ b/ui_qt/resources/ui_qt.qrc
@@ -1,0 +1,9 @@
+<RCC>
+  <qresource prefix="/icons">
+    <file>icons/arrow_up.svg</file>
+    <file>icons/arrow_down.svg</file>
+    <file>icons/arrow_left.svg</file>
+    <file>icons/arrow_right.svg</file>
+    <file>icons/dot_center.svg</file>
+  </qresource>
+</RCC>


### PR DESCRIPTION
## Summary
- Introduce SVG icon resources and qrc for movement controls
- Redesign MainWindow with grouped layouts and warm beige/white stylesheet
- Add key actions and log trimming for responsive UI

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --target ui_qt -j`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_689725828ec4832c949af769bda21219