### PR TITLE
feat: add room panel with directional exits

### DIFF
--- a/ui_qt/MainWindow.cpp
+++ b/ui_qt/MainWindow.cpp
@@ -156,6 +156,10 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent) {
     connect(btnS_, &QPushButton::clicked, this, &MainWindow::onMoveSouth);
     connect(btnW_, &QPushButton::clicked, this, &MainWindow::onMoveWest);
     connect(btnE_, &QPushButton::clicked, this, &MainWindow::onMoveEast);
+    connect(map_, &MapWidget::moveNorth, this, &MainWindow::onMoveNorth);
+    connect(map_, &MapWidget::moveSouth, this, &MainWindow::onMoveSouth);
+    connect(map_, &MapWidget::moveWest, this, &MainWindow::onMoveWest);
+    connect(map_, &MapWidget::moveEast, this, &MainWindow::onMoveEast);
     connect(btnTalk_, &QPushButton::clicked, this, &MainWindow::onTalk);
     connect(btnAttack_, &QPushButton::clicked, this, &MainWindow::onAttack);
     connect(btnSave_, &QPushButton::clicked, this, &MainWindow::onSave);

--- a/ui_qt/MapWidget.cpp
+++ b/ui_qt/MapWidget.cpp
@@ -1,6 +1,14 @@
+/*
+ * MapWidget now draws a room-style panel showing the current location and
+ * exits. The center cell is highlighted; reachable directions are rendered as
+ * buttons. Clicking a direction emits a corresponding signal.
+ */
+#pragma execution_character_set("utf-8")
 #include "MapWidget.h"
 #include <QPainter>
 #include <QSizePolicy>
+#include <QMouseEvent>
+#include <QStringList>
 
 MapWidget::MapWidget(World* world, QWidget* parent)
     : QWidget(parent), world_(world) {
@@ -10,28 +18,77 @@ MapWidget::MapWidget(World* world, QWidget* parent)
 
 void MapWidget::paintEvent(QPaintEvent*) {
     QPainter p(this);
-    if (!world_) return;
-    int w = world_->width();
-    int h = world_->height();
-    if (w <= 0 || h <= 0) return;
-    int cellW = width() / w;
-    int cellH = height() / h;
-    int cell = std::min(cellW, cellH);
-    if (cell <= 0) return;
-
     p.fillRect(rect(), Qt::white);
-    for (int y = 0; y < h; ++y) {
-        for (int x = 0; x < w; ++x) {
-            QRect r(x * cell, y * cell, cell, cell);
-            QColor color = world_->Walkable({x, y}) ? QColor("#f0f0f0") : QColor("#9ca3af");
-            p.fillRect(r, color);
-            p.drawRect(r);
+    if (!world_) return;
+
+    // bottom info line height
+    const int infoH = 24;
+    QRect area = rect().adjusted(0, 0, 0, -infoH);
+
+    int cell = std::min(area.width(), area.height()) / 3;
+    if (cell <= 0) return;
+    int offX = area.left() + (area.width() - cell * 3) / 2;
+    int offY = area.top() + (area.height() - cell * 3) / 2;
+
+    rectC_ = QRect(offX + cell, offY + cell, cell, cell);
+    rectN_ = QRect(offX + cell, offY, cell, cell);
+    rectS_ = QRect(offX + cell, offY + 2 * cell, cell, cell);
+    rectW_ = QRect(offX, offY + cell, cell, cell);
+    rectE_ = QRect(offX + 2 * cell, offY + cell, cell, cell);
+
+    auto* player = world_->Find(world_->playerId());
+    if (!player) return;
+
+    QColor highlight("#3b82f6");
+    p.fillRect(rectC_, QColor("#fef3c7"));
+    p.setPen(highlight);
+    p.drawRect(rectC_);
+
+    QString name = QString("%1,%2").arg(player->pos.x).arg(player->pos.y);
+    p.drawText(rectC_, Qt::AlignCenter, name);
+
+    struct Dir { QRect* r; Vec2 d; const char* text; };
+    Dir dirs[4] = {
+        { &rectN_, {0,-1}, "北" },
+        { &rectS_, {0,1},  "南" },
+        { &rectW_, {-1,0}, "西" },
+        { &rectE_, {1,0},  "东" }
+    };
+
+    for (auto& d : dirs) {
+        Vec2 np{ player->pos.x + d.d.x, player->pos.y + d.d.y };
+        if (world_->Walkable(np)) {
+            p.setPen(Qt::black);
+            p.drawRect(*d.r);
+            p.drawText(*d.r, Qt::AlignCenter, QString::fromUtf8(d.text));
+        } else {
+            p.fillRect(*d.r, Qt::black);
+            p.setPen(Qt::black);
+            p.drawRect(*d.r);
         }
     }
+
+    // bottom info
+    QStringList names;
     for (const auto& e : world_->entities()) {
-        QRect r(e.pos.x * cell, e.pos.y * cell, cell, cell);
-        QColor color = e.isPlayer ? QColor("#ef4444") : QColor("#3b82f6");
-        p.fillRect(r, color);
-        p.drawRect(r);
+        if (e.id != player->id && e.pos.x == player->pos.x && e.pos.y == player->pos.y) {
+            names << QString::fromStdString(e.name);
+        }
     }
+    QString info = names.isEmpty() ? QStringLiteral("这里空无一人")
+                                   : QStringLiteral("这里有") + names.join(QStringLiteral("、"));
+    p.setPen(Qt::black);
+    p.drawText(QRect(4, height() - infoH, width() - 8, infoH), Qt::AlignVCenter | Qt::AlignLeft, info);
+
+    // bottom separator line
+    p.setPen(QColor("#d1d5db"));
+    p.drawLine(0, height() - 1, width(), height() - 1);
+}
+
+void MapWidget::mouseReleaseEvent(QMouseEvent* e) {
+    QPoint pt = e->pos();
+    if (rectN_.contains(pt)) emit moveNorth();
+    else if (rectS_.contains(pt)) emit moveSouth();
+    else if (rectW_.contains(pt)) emit moveWest();
+    else if (rectE_.contains(pt)) emit moveEast();
 }

--- a/ui_qt/MapWidget.h
+++ b/ui_qt/MapWidget.h
@@ -1,13 +1,21 @@
 #pragma once
 #include <QWidget>
+#include <QRect>
 #include "../core/World.h"
 
 class MapWidget : public QWidget {
     Q_OBJECT
 public:
     explicit MapWidget(World* world, QWidget* parent=nullptr);
+signals:
+    void moveNorth();
+    void moveSouth();
+    void moveWest();
+    void moveEast();
 protected:
     void paintEvent(QPaintEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
 private:
     World* world_;
+    QRect rectN_, rectS_, rectW_, rectE_, rectC_;
 };


### PR DESCRIPTION
## Summary
- replace map view with room-style panel and highlight current location
- show reachable exits as clickable buttons and list co-located NPCs
- wire new panel movement signals into main window
- mark MapWidget.cpp as UTF-8 to fix invalid-character warnings

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68973aeb1480832cb5da7476d0bc37d8