### PR TITLE
Improve map display and UI interactions

### DIFF
--- a/ui_qt/MainWindow.h
+++ b/ui_qt/MainWindow.h
@@ -1,8 +1,9 @@
 ﻿#pragma once
 #include <QMainWindow>
 #include <QTimer>
-#include <QPlainTextEdit>
+#include <QTextEdit>
 #include <QPushButton>
+#include <QColor>
 #include <QGroupBox>
 #include <QGridLayout>
 #include "../core/World.h"
@@ -17,8 +18,8 @@ public:
 private:
     World world_;
     MapWidget* map_;
-    QPlainTextEdit* log_;
-    QPushButton *btnN_,*btnS_,*btnW_,*btnE_,*btnSave_,*btnLoad_,*btnClear_;
+    QTextEdit* log_;
+    QPushButton *btnN_,*btnS_,*btnW_,*btnE_,*btnInfo_,*btnBag_,*btnSettings_,*btnSave_,*btnLoad_,*btnClear_;
     QGroupBox* grpInteract_;
     QGridLayout* interactLayout_;
     QPushButton *btnChat_,*btnObserve_,*btnTouch_,*btnAttack_,*btnTrade_,*btnLeave_;
@@ -26,7 +27,7 @@ private:
     QTimer* timer_;
     int tick_=0;
     QString dataVersion_;
-    void append(const QString& s);
+    void append(const QString& s, const QColor& color=Qt::black);
     void refreshHud();
     void onMoveNorth();
     void onMoveSouth();
@@ -40,6 +41,9 @@ private:
     void onTrade();
     void onLeave();
     void clearInteraction();
+    void onInfo();
+    void onBag();
+    void onSettings();
     void onSave();
     void onLoad();
     void onClear();

--- a/ui_qt/MapWidget.cpp
+++ b/ui_qt/MapWidget.cpp
@@ -2,11 +2,13 @@
 #include <QPainter>
 #include <QMouseEvent>
 #include <QFontMetrics>
+#include <QStringList>
 
 MapWidget::MapWidget(World* world, QWidget* parent)
     : QWidget(parent), world_(world) {
     setMinimumHeight(200);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    setMouseTracking(true);
 }
 
 void MapWidget::paintEvent(QPaintEvent*) {
@@ -25,20 +27,36 @@ void MapWidget::paintEvent(QPaintEvent*) {
     int cellSize = std::min(area.width(), area.height()) / 3;
     int ox = area.center().x() - cellSize * 3 / 2;
     int oy = area.center().y() - cellSize * 3 / 2;
-
-    p.setPen(QColor("#d1d5db"));
-    for (int i = 0; i <= 3; ++i) {
-        p.drawLine(ox, oy + i * cellSize, ox + 3 * cellSize, oy + i * cellSize);
-        p.drawLine(ox + i * cellSize, oy, ox + i * cellSize, oy + 3 * cellSize);
-    }
-
     for (int dy = -1; dy <= 1; ++dy) {
         for (int dx = -1; dx <= 1; ++dx) {
             QRect cell(ox + (dx + 1) * cellSize, oy + (dy + 1) * cellSize, cellSize, cellSize);
             Vec2 np{ player->pos.x + dx, player->pos.y + dy };
+            if (!world_->Walkable(np)) continue;
+            if (dx == 0 && dy == 0) {
+                p.fillRect(cell, QColor("#fef9c3"));
+            }
+            p.setPen(QColor("#d1d5db"));
+            p.drawRect(cell);
             QString name = QString::fromStdString(world_->TagName(np));
             p.setPen(Qt::black);
             p.drawText(cell, Qt::AlignCenter, name);
+
+            bool hasNpc = false;
+            for (const auto& e : world_->entities()) {
+                if (e.id != player->id && e.pos.x == np.x && e.pos.y == np.y) {
+                    hasNpc = true;
+                    break;
+                }
+            }
+            if (hasNpc) {
+                int r = cellSize / 8;
+                QPoint center = cell.topLeft() + QPoint(r*2, r*2);
+                p.setBrush(QColor("#2563eb"));
+                p.setPen(Qt::NoPen);
+                p.drawEllipse(center, r, r);
+                p.setPen(Qt::black);
+                p.setBrush(Qt::NoBrush);
+            }
         }
     }
 
@@ -85,4 +103,29 @@ void MapWidget::mouseReleaseEvent(QMouseEvent* e) {
             break;
         }
     }
+}
+
+void MapWidget::mouseMoveEvent(QMouseEvent* e) {
+    if (!world_) { setToolTip(QString()); return; }
+    const int infoH = 32;
+    QRect area = rect().adjusted(0, 0, 0, -infoH);
+    auto* player = world_->Find(world_->playerId());
+    if (!player) { setToolTip(QString()); return; }
+    int cellSize = std::min(area.width(), area.height()) / 3;
+    int ox = area.center().x() - cellSize * 3 / 2;
+    int oy = area.center().y() - cellSize * 3 / 2;
+    int cx = (e->pos().x() - ox) / cellSize - 1;
+    int cy = (e->pos().y() - oy) / cellSize - 1;
+    if (cx < -1 || cx > 1 || cy < -1 || cy > 1) { setToolTip(QString()); return; }
+    Vec2 np{ player->pos.x + cx, player->pos.y + cy };
+    if (!world_->Walkable(np)) { setToolTip(QString()); return; }
+    QString tip = QString::fromStdString(world_->TagName(np));
+    QStringList names;
+    for (const auto& en : world_->entities()) {
+        if (en.id != player->id && en.pos.x == np.x && en.pos.y == np.y) {
+            names << QString::fromStdString(en.name);
+        }
+    }
+    if (!names.isEmpty()) tip += QStringLiteral("\nNPC: ") + names.join(", ");
+    setToolTip(tip);
 }

--- a/ui_qt/MapWidget.h
+++ b/ui_qt/MapWidget.h
@@ -12,6 +12,7 @@ signals:
 protected:
     void paintEvent(QPaintEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
 private:
     World* world_;
     std::vector<std::pair<QRect, int>> npcRects_;


### PR DESCRIPTION
## Summary
- Hide non-walkable tiles and highlight player tile; show NPC markers and dynamic tile tooltips
- Color-code log messages and add placeholders for info/bag/settings
- Expand system button grid to two rows of six equal buttons

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT" with any of the following names: Qt6Config.cmake Qt5Config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68974aba1af0832c965e2c00eb003271