### PR TITLE
Integrate NPC data for palace interactions

### DIFF
--- a/core/Data.cpp
+++ b/core/Data.cpp
@@ -102,3 +102,27 @@ bool LoadDialogsJson(const std::string& path, DialogMap& out, std::string* err) 
     }
 }
 
+bool LoadNpcsJson(const std::string& path, std::vector<NpcDef>& out, std::string* err) {
+    json j;
+    if (!read_json(path, j, err)) return false;
+    try {
+        out.clear();
+        for (const auto& item : j) {
+            NpcDef npc;
+            npc.name = item.value("name", std::string{});
+            npc.tile = item.value("tile", std::string{});
+            if (item.contains("interactions")) {
+                for (auto it = item["interactions"].begin(); it != item["interactions"].end(); ++it) {
+                    npc.interactions[it.key()] = it.value().get<std::string>();
+                }
+            }
+            out.push_back(std::move(npc));
+        }
+        return true;
+    }
+    catch (const std::exception& e) {
+        if (err) *err = std::string("npc.json 解析失败: ") + e.what();
+        return false;
+    }
+}
+

--- a/core/Data.h
+++ b/core/Data.h
@@ -21,6 +21,13 @@ struct MapData {
 
 using DialogMap = std::unordered_map<int, std::vector<std::string>>; // npcId -> lines
 
+struct NpcDef {
+        std::string name;                                 // NPC名称
+        std::string tile;                                 // 所在地块名称
+        std::unordered_map<std::string, std::string> interactions; // 行为 -> 文本
+};
+
 bool LoadMapJson(const std::string& path, MapData& out, std::string* err = nullptr);
 bool LoadEntitiesJson(const std::string& path, std::vector<Entity>& out, std::string* err = nullptr);
 bool LoadDialogsJson(const std::string& path, DialogMap& out, std::string* err = nullptr);
+bool LoadNpcsJson(const std::string& path, std::vector<NpcDef>& out, std::string* err = nullptr);

--- a/core/World.h
+++ b/core/World.h
@@ -2,6 +2,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include <unordered_map>
 #include "Entity.h"
 #include "Data.h"
 #include "GameClock.h"
@@ -16,6 +17,7 @@ public:
     bool Move(EntityId id, Vec2 dxy);
     std::string Talk(EntityId a, EntityId b);
     std::string Attack(EntityId a, EntityId b);
+    std::string Interact(EntityId a, EntityId b, const std::string& action);
 
     int width() const { return w_; }
     int height() const { return h_; }
@@ -45,4 +47,7 @@ private:
     bool InBounds(Vec2 p) const { return p.x >= 0 && p.y >= 0 && p.x < w_ && p.y < h_; }
     std::string dataFolder_;
     std::string mapFile_;
+    struct NpcInfo { std::unordered_map<std::string, std::string> interactions; };
+    std::unordered_map<EntityId, NpcInfo> npcData_;
+    std::string AttackCombat(EntityId a, EntityId b);
 };

--- a/ui_qt/MainWindow.cpp
+++ b/ui_qt/MainWindow.cpp
@@ -265,11 +265,11 @@ void MainWindow::onChat() {
 }
 
 void MainWindow::onObserve() {
-    if (selectedNpc_) append(QStringLiteral("你仔细地观察了对方。"), QColor("#2563eb"));
+    if (selectedNpc_) append(QString::fromStdString(world_.Interact(world_.playerId(), selectedNpc_, "观察")), QColor("#2563eb"));
 }
 
 void MainWindow::onTouch() {
-    if (selectedNpc_) append(QStringLiteral("你摸了摸对方。"), QColor("#2563eb"));
+    if (selectedNpc_) append(QString::fromStdString(world_.Interact(world_.playerId(), selectedNpc_, "触摸")), QColor("#2563eb"));
 }
 
 void MainWindow::onAttack() {
@@ -277,10 +277,11 @@ void MainWindow::onAttack() {
 }
 
 void MainWindow::onTrade() {
-    if (selectedNpc_) append(QStringLiteral("目前没有可交易的物品。"), QColor("#2563eb"));
+    if (selectedNpc_) append(QString::fromStdString(world_.Interact(world_.playerId(), selectedNpc_, "交易")), QColor("#2563eb"));
 }
 
 void MainWindow::onLeave() {
+    if (selectedNpc_) append(QString::fromStdString(world_.Interact(world_.playerId(), selectedNpc_, "离开")), QColor("#2563eb"));
     clearInteraction();
 }
 


### PR DESCRIPTION
## Summary
- Load npc.json and create NPC entities at matching map tags
- Add generic interaction system and hook Talk/Attack into NPC responses
- Wire GUI buttons to trigger NPC interactions

## Testing
- `ctest` *(no tests found)*
- `pytest` *(0 tests collected)*

------
https://chatgpt.com/codex/tasks/task_e_6897f86df7d0832c8f746d53ca505ce6