### PR TITLE
feat: highlight selected npc in map panel

### DIFF
--- a/ui_qt/MainWindow.cpp
+++ b/ui_qt/MainWindow.cpp
@@ -231,6 +231,7 @@ void MainWindow::onMoveNorth() {
     append(QString::fromStdString(Execute(world_, world_.playerId(), {"go", "north", {}})), QColor("#6b7280"));
     if (auto desc = QString::fromStdString(world_.TagDesc(world_.Find(world_.playerId())->pos)); !desc.isEmpty())
         append(desc);
+    clearInteraction();
     refreshHud();
 }
 
@@ -238,6 +239,7 @@ void MainWindow::onMoveSouth() {
     append(QString::fromStdString(Execute(world_, world_.playerId(), {"go", "south", {}})), QColor("#6b7280"));
     if (auto desc = QString::fromStdString(world_.TagDesc(world_.Find(world_.playerId())->pos)); !desc.isEmpty())
         append(desc);
+    clearInteraction();
     refreshHud();
 }
 
@@ -245,6 +247,7 @@ void MainWindow::onMoveWest() {
     append(QString::fromStdString(Execute(world_, world_.playerId(), {"go", "west", {}})), QColor("#6b7280"));
     if (auto desc = QString::fromStdString(world_.TagDesc(world_.Find(world_.playerId())->pos)); !desc.isEmpty())
         append(desc);
+    clearInteraction();
     refreshHud();
 }
 
@@ -252,11 +255,13 @@ void MainWindow::onMoveEast() {
     append(QString::fromStdString(Execute(world_, world_.playerId(), {"go", "east", {}})), QColor("#6b7280"));
     if (auto desc = QString::fromStdString(world_.TagDesc(world_.Find(world_.playerId())->pos)); !desc.isEmpty())
         append(desc);
+    clearInteraction();
     refreshHud();
 }
 
 void MainWindow::onNpcClicked(int id) {
     selectedNpc_ = id;
+    map_->setSelectedNpc(id);
     for (auto btn : {btnChat_, btnObserve_, btnTouch_, btnAttack_, btnTrade_, btnLeave_}) btn->show();
 }
 
@@ -287,6 +292,7 @@ void MainWindow::onLeave() {
 
 void MainWindow::clearInteraction() {
     selectedNpc_ = 0;
+    if (map_) map_->setSelectedNpc(0);
     for (auto btn : {btnChat_, btnObserve_, btnTouch_, btnAttack_, btnTrade_, btnLeave_}) btn->hide();
 }
 
@@ -297,6 +303,7 @@ void MainWindow::onSave() {
 void MainWindow::onLoad() {
     append(QString::fromStdString(world_.Load("save1.json")), QColor("#6b7280"));
     lastShichen_ = world_.clock().shichen();
+    clearInteraction();
     refreshHud();
 }
 

--- a/ui_qt/MapWidget.cpp
+++ b/ui_qt/MapWidget.cpp
@@ -129,10 +129,21 @@ void MapWidget::paintEvent(QPaintEvent*) {
             const QString& nm = names[i];
             int w = fm.horizontalAdvance(nm) + 16;
             QRect tag(x, y, w, infoH - 8);
+
+            QColor fill("#e5e7eb");
+            QColor text("#374151");
+            if (ids[i] == selectedNpc_) {
+                fill = QColor("#facc15");
+                text = QColor("#78350f");
+            } else if (ids[i] == hoveredNpc_) {
+                fill = QColor("#f3f4f6");
+                text = QColor("#111827");
+            }
+
             p.setPen(Qt::NoPen);
-            p.setBrush(QColor("#e5e7eb"));
+            p.setBrush(fill);
             p.drawRoundedRect(tag, (infoH - 8) / 2, (infoH - 8) / 2);
-            p.setPen(QColor("#374151"));
+            p.setPen(text);
             p.drawText(tag, Qt::AlignCenter, nm);
             npcRects_.push_back({ tag, ids[i] });
             x += w + 6;
@@ -147,14 +158,22 @@ void MapWidget::mouseReleaseEvent(QMouseEvent* e) {
     QPoint pt = e->pos();
     for (auto& pr : npcRects_) {
         if (pr.first.contains(pt)) {
+            setSelectedNpc(pr.second);
             emit npcClicked(pr.second);
-            break;
+            return;
         }
     }
 }
 
 void MapWidget::mouseMoveEvent(QMouseEvent* e) {
     if (!world_) { setToolTip(QString()); return; }
+
+    int hover = 0;
+    for (auto& pr : npcRects_) {
+        if (pr.first.contains(e->pos())) { hover = pr.second; break; }
+    }
+    if (hoveredNpc_ != hover) { hoveredNpc_ = hover; update(); }
+    if (hover) { setToolTip(QString()); return; }
     const int infoH = 32;
     QRect area = rect().adjusted(0, 0, 0, -infoH);
     auto* player = world_->Find(world_->playerId());

--- a/ui_qt/MapWidget.h
+++ b/ui_qt/MapWidget.h
@@ -13,6 +13,8 @@ public:
     QColor highlightColor() const { return highlightColor_; }
     void setHighlightColor(const QColor& c) { highlightColor_ = c; update(); }
 
+    void setSelectedNpc(int id) { selectedNpc_ = id; update(); }
+
 signals:
     void npcClicked(int id);
 
@@ -27,4 +29,6 @@ private:
     Vec2 lastPlayerPos_{};
     bool hasLastPos_ = false;
     QColor highlightColor_ { QColor("#fef9c3") };
+    int selectedNpc_ = 0;
+    int hoveredNpc_ = 0;
 };


### PR DESCRIPTION
## Summary
- highlight selected NPC tag in location panel with yellow and hover with light gray
- reset NPC selection when moving, loading, or closing interactions

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_6897fd260f84832c872461f98c5dd7ce