### PR TITLE
Add full map view window

### DIFF
--- a/ui_qt/CMakeLists.txt
+++ b/ui_qt/CMakeLists.txt
@@ -11,6 +11,8 @@ add_executable(ui_qt
   MainWindow.h
   MapWidget.cpp
   MapWidget.h
+  FullMapWindow.cpp
+  FullMapWindow.h
 )
 
 target_link_libraries(ui_qt PRIVATE core Qt${QT_VERSION_MAJOR}::Widgets)

--- a/ui_qt/FullMapWindow.cpp
+++ b/ui_qt/FullMapWindow.cpp
@@ -1,0 +1,36 @@
+#include "FullMapWindow.h"
+#include <QPainter>
+#include <algorithm>
+
+FullMapWindow::FullMapWindow(World* world, QWidget* parent)
+    : QWidget(parent), world_(world) {
+    setWindowTitle(QStringLiteral("地图"));
+    resize(400, 400);
+}
+
+void FullMapWindow::paintEvent(QPaintEvent*) {
+    QPainter p(this);
+    p.fillRect(rect(), Qt::white);
+    if (!world_) return;
+    int w = world_->width();
+    int h = world_->height();
+    if (w <= 0 || h <= 0) return;
+    int cell = std::min(width() / w, height() / h);
+    if (cell <= 0) return;
+    int ox = (width() - cell * w) / 2;
+    int oy = (height() - cell * h) / 2;
+    auto* player = world_->Find(world_->playerId());
+    for (int y = 0; y < h; ++y) {
+        for (int x = 0; x < w; ++x) {
+            QRect r(ox + x * cell, oy + y * cell, cell, cell);
+            bool walk = world_->Walkable({x, y});
+            p.fillRect(r, walk ? Qt::white : QColor("#e5e7eb"));
+            if (player && player->pos.x == x && player->pos.y == y) {
+                p.fillRect(r, QColor("#facc15"));
+            }
+            p.setPen(QColor("#d1d5db"));
+            p.drawRect(r);
+        }
+    }
+}
+

--- a/ui_qt/FullMapWindow.h
+++ b/ui_qt/FullMapWindow.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <QWidget>
+#include "../core/World.h"
+
+class FullMapWindow : public QWidget {
+    Q_OBJECT
+public:
+    explicit FullMapWindow(World* world, QWidget* parent=nullptr);
+protected:
+    void paintEvent(QPaintEvent* event) override;
+private:
+    World* world_;
+};
+

--- a/ui_qt/MainWindow.h
+++ b/ui_qt/MainWindow.h
@@ -19,7 +19,7 @@ private:
     World world_;
     MapWidget* map_;
     QTextEdit* log_;
-    QPushButton *btnN_,*btnS_,*btnW_,*btnE_,*btnInfo_,*btnBag_,*btnSettings_,*btnSave_,*btnLoad_,*btnClear_;
+    QPushButton *btnN_,*btnS_,*btnW_,*btnE_,*btnInfo_,*btnBag_,*btnSettings_,*btnSave_,*btnLoad_,*btnClear_,*btnMap_;
     QGroupBox* grpInteract_;
     QGridLayout* interactLayout_;
     QPushButton *btnChat_,*btnObserve_,*btnTouch_,*btnAttack_,*btnTrade_,*btnLeave_;
@@ -28,6 +28,7 @@ private:
     int tick_=0;
     int lastShichen_ = -1;
     QString dataVersion_;
+    class FullMapWindow* fullMap_ = nullptr;
     void append(const QString& s, const QColor& color=Qt::black);
     void refreshHud();
     void onMoveNorth();
@@ -48,4 +49,5 @@ private:
     void onSave();
     void onLoad();
     void onClear();
+    void onMap();
 };


### PR DESCRIPTION
## Summary
- Add a FullMapWindow widget to display the entire map and highlight the player's position
- Wire a new “地图” button and M shortcut in the main window to open the full map
- Update build files and HUD refresh to support the new map view

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_689e02314818832c9205f97f212d31ef